### PR TITLE
Update JWTGenerateCommand.php

### DIFF
--- a/src/Commands/JWTGenerateCommand.php
+++ b/src/Commands/JWTGenerateCommand.php
@@ -32,6 +32,14 @@ class JWTGenerateCommand extends Command
     protected $description = 'Set the JWTAuth secret key used to sign the tokens';
 
     /**
+    * Compatiblity with laravel >= 5.5 
+    *
+    */
+    public function handle() {
+        $this->fire();
+    }
+    
+    /**
      * Execute the console command.
      *
      * @return void


### PR DESCRIPTION
Caompatibility with laravel 5.5,

Add method handle() in the file /src/Commands/WTGenerateCommand.php

for resolve the exception:

> In BoundMethod.php line 135:
>                                                                              
>   Method Tymon\JWTAuth\Commands\JWTGenerateCommand::handle() does not exist  
>                                                                              
